### PR TITLE
hermes_cli/config.py: pin UTF-8 encoding unconditionally on .env I/O

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1466,18 +1466,22 @@ def load_env() -> Dict[str, str]:
     """Load environment variables from ~/.hermes/.env."""
     env_path = get_env_path()
     env_vars = {}
-    
+
     if env_path.exists():
-        # On Windows, open() defaults to the system locale (cp1252) which can
-        # fail on UTF-8 .env files. Use explicit UTF-8 only on Windows.
-        open_kw = {"encoding": "utf-8", "errors": "replace"} if _IS_WINDOWS else {}
-        with open(env_path, **open_kw) as f:
+        # Explicit UTF-8 unconditionally: open()'s default encoding is
+        # locale-dependent and not guaranteed UTF-8 even on POSIX (any
+        # container/embedded Linux with no LANG set, locale-misconfigured
+        # macOS, etc. can hit the same trap that Windows cp1252 hits).
+        # PEP 597 also flags locale-default open() as a deprecation
+        # candidate. Pinning UTF-8 is correct on every platform.
+        # errors='replace' so a corrupt byte doesn't kill the whole load.
+        with open(env_path, encoding="utf-8", errors="replace") as f:
             for line in f:
                 line = line.strip()
                 if line and not line.startswith('#') and '=' in line:
                     key, _, value = line.partition('=')
                     env_vars[key.strip()] = value.strip().strip('"\'')
-    
+
     return env_vars
 
 
@@ -1542,8 +1546,11 @@ def sanitize_env_file() -> int:
     if not env_path.exists():
         return 0
 
-    read_kw = {"encoding": "utf-8", "errors": "replace"} if _IS_WINDOWS else {}
-    write_kw = {"encoding": "utf-8"} if _IS_WINDOWS else {}
+    # Unconditional UTF-8 on every platform — see load_env() above for
+    # the rationale (locale-default open() is not guaranteed UTF-8 on
+    # POSIX either; pinning is the only safe pattern).
+    read_kw = {"encoding": "utf-8", "errors": "replace"}
+    write_kw = {"encoding": "utf-8"}
 
     with open(env_path, **read_kw) as f:
         original_lines = f.readlines()
@@ -1587,11 +1594,13 @@ def save_env_value(key: str, value: str):
     value = value.replace("\n", "").replace("\r", "")
     ensure_hermes_home()
     env_path = get_env_path()
-    
-    # On Windows, open() defaults to the system locale (cp1252) which can
-    # cause OSError errno 22 on UTF-8 .env files.
-    read_kw = {"encoding": "utf-8", "errors": "replace"} if _IS_WINDOWS else {}
-    write_kw = {"encoding": "utf-8"} if _IS_WINDOWS else {}
+
+    # Unconditional UTF-8 on every platform — see load_env() above. The
+    # previous Windows-only conditional left POSIX hosts exposed to the
+    # same trap when LANG is unset or locale.getpreferredencoding() is
+    # ANSI-X3.4 (some minimal containers, locale-broken systems).
+    read_kw = {"encoding": "utf-8", "errors": "replace"}
+    write_kw = {"encoding": "utf-8"}
 
     lines = []
     if env_path.exists():


### PR DESCRIPTION
## Summary

The three `.env` reader/writer helpers in `hermes_cli/config.py` (`load_env`, `sanitize_env_file`, `save_env_value`) currently gate explicit UTF-8 encoding on `_IS_WINDOWS`. This patch removes the conditional and pins UTF-8 + `errors="replace"` on all six `open()` calls.

## Why this matters on non-Windows hosts

The original conditional treats the cp1252 default-encoding trap as Windows-only. It isn't. Python's `open()` default encoding on POSIX is `locale.getpreferredencoding(False)`, which is *usually* UTF-8 on modern desktop Linux/macOS — but not always:

- **Minimal containers** (Alpine, distroless, scratch) without `LANG` or `LC_*` set default to `ANSI_X3.4-1968` (effectively ASCII-only). `hermes login` writing a token with a UTF-8 multi-byte char will raise `UnicodeEncodeError` there. Same for `.env` files copied in from a host with curly quotes / em-dashes in comments.
- **macOS hosts with locale config drift** (e.g. after a homebrew update that bumps `gettext`) fall back to ASCII the same way — the classic `Could not locate the LC_CTYPE locale` warning.
- **Python builds compiled with `--without-locale`** (some embedded distributions) behave the same.

[PEP 597](https://peps.python.org/pep-0597/) documents this trap and ships `-X warn_default_encoding` to flag locale-default `open()` calls. The long-term direction is toward requiring explicit encoding everywhere.

## The patch

```diff
 def load_env() -> Dict[str, str]:
     ...
     if env_path.exists():
-        # On Windows, open() defaults to the system locale (cp1252) which can
-        # fail on UTF-8 .env files. Use explicit UTF-8 only on Windows.
-        open_kw = {"encoding": "utf-8", "errors": "replace"} if _IS_WINDOWS else {}
-        with open(env_path, **open_kw) as f:
+        # Explicit UTF-8 unconditionally: open()'s default encoding is
+        # locale-dependent and not guaranteed UTF-8 even on POSIX (any
+        # container/embedded Linux with no LANG set, locale-misconfigured
+        # macOS, etc. can hit the same trap that Windows cp1252 hits).
+        # PEP 597 also flags locale-default open() as a deprecation
+        # candidate. Pinning UTF-8 is correct on every platform.
+        # errors='replace' so a corrupt byte doesn't kill the whole load.
+        with open(env_path, encoding="utf-8", errors="replace") as f:
```

Same pattern in `sanitize_env_file` (`read_kw`/`write_kw` definitions) and `save_env_value` (same `read_kw`/`write_kw`).

## Why `errors="replace"` on read paths

A single corrupt byte in `~/.hermes/.env` (e.g. from a partially-written save or a tool that mangled the file) shouldn't take down the agent. `hermes config show` should be able to display the bad value with replacement chars, letting the operator see and fix it manually. The write paths use strict UTF-8 — if hermes-agent itself produces a non-UTF-8 value, that's a hermes bug worth surfacing loudly.

## Verification

Tested on Windows 11 (Python 3.13.12 embedded): full smoke test post-patch, ACP session boots cleanly, `hermes config set/show/login` all read/write correctly. Caveat: I don't have a non-UTF-8 POSIX environment to repro the original symptom — the patch is defense-in-depth for hosts I can describe but not directly test. The behavior on a locale-correct Linux/macOS is byte-identical to the previous code path because UTF-8 was already the implicit default there.

## Out of scope

`hermes_cli/config.py` has additional file I/O sites that already use explicit UTF-8 (yaml config read/write at line 1314, etc.) — left alone. This PR focuses on the `.env` helper trio because they were the only callsites with the Windows-conditional pattern.

Related cp1252 sites exist elsewhere in the tree (`cli.py:252,596,985,1000,5719,6331`; `agent/model_metadata.py:511,533`; `cron/scheduler.py:332`; `gateway/platforms/telegram.py:355,1777`). Happy to follow up with a sweep PR if the maintainer wants — kept this diff focused on one logical change for review clarity.
