### PR TITLE
Add EvoLink provider support

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -60,6 +60,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "minimax-cn": "MiniMax-M2.7-highspeed",
     "anthropic": "claude-haiku-4-5-20251001",
     "ai-gateway": "google/gemini-3-flash",
+    "evolink": "google/gemini-3-flash",
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -25,12 +25,13 @@ logger = logging.getLogger(__name__)
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic", "deepseek",
-    "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba",
+    "opencode-zen", "opencode-go", "ai-gateway", "evolink", "kilocode", "alibaba",
     "custom", "local",
     # Common aliases
     "glm", "z-ai", "z.ai", "zhipu", "github", "github-copilot",
     "github-models", "kimi", "moonshot", "claude", "deep-seek",
-    "opencode", "zen", "go", "vercel", "kilo", "dashscope", "aliyun", "qwen",
+    "opencode", "zen", "go", "vercel", "evo-link", "evolink-ai", "evolink.ai",
+    "kilo", "dashscope", "aliyun", "qwen",
 })
 
 
@@ -175,6 +176,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.deepseek.com": "deepseek",
     "api.githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
+    "api.evolink.ai": "evolink",
 }
 
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -25,6 +25,7 @@ model:
   #   "huggingface"  - Hugging Face Inference (requires: HF_TOKEN)
   #   "kilocode"     - KiloCode gateway (requires: KILOCODE_API_KEY)
   #   "ai-gateway"   - Vercel AI Gateway (requires: AI_GATEWAY_API_KEY)
+  #   "evolink"      - EvoLink OpenAI-compatible gateway (requires: EVOLINK_API_KEY)
   #
   # Local servers (LM Studio, Ollama, vLLM, llama.cpp):
   #   "custom"       - Any OpenAI-compatible endpoint. Set base_url below.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -188,6 +188,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("AI_GATEWAY_API_KEY",),
         base_url_env_var="AI_GATEWAY_BASE_URL",
     ),
+    "evolink": ProviderConfig(
+        id="evolink",
+        name="EvoLink",
+        auth_type="api_key",
+        inference_base_url="https://api.evolink.ai/v1",
+        api_key_env_vars=("EVOLINK_API_KEY",),
+        base_url_env_var="EVOLINK_BASE_URL",
+    ),
     "opencode-zen": ProviderConfig(
         id="opencode-zen",
         name="OpenCode Zen",
@@ -692,6 +700,7 @@ def resolve_provider(
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
+        "evo-link": "evolink", "evolink-ai": "evolink", "evolink.ai": "evolink",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -575,6 +575,22 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "provider",
     },
+    "EVOLINK_API_KEY": {
+        "description": "EvoLink API key",
+        "prompt": "EvoLink API key",
+        "url": "https://evolink.ai",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "EVOLINK_BASE_URL": {
+        "description": "EvoLink base URL override",
+        "prompt": "EvoLink base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
     "DASHSCOPE_API_KEY": {
         "description": "Alibaba Cloud DashScope API key (Qwen + multi-provider models)",
         "prompt": "DashScope API Key",

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -43,6 +43,7 @@ _PROVIDER_ENV_HINTS = (
     "KIMI_API_KEY",
     "MINIMAX_API_KEY",
     "MINIMAX_CN_API_KEY",
+    "EVOLINK_API_KEY",
     "KILOCODE_API_KEY",
 )
 
@@ -569,6 +570,7 @@ def run_doctor(args):
         ("MiniMax",          ("MINIMAX_API_KEY",),                            None,                                  "MINIMAX_BASE_URL", False),
         ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         None,                                  "MINIMAX_CN_BASE_URL", False),
         ("AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
+        ("EvoLink",          ("EVOLINK_API_KEY",),                             "https://api.evolink.ai/v1/models",       "EVOLINK_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),
     ]
     for _pname, _env_vars, _default_url, _base_env, _supports_health_check in _apikey_providers:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -858,6 +858,7 @@ def cmd_model(args):
         "opencode-zen": "OpenCode Zen",
         "opencode-go": "OpenCode Go",
         "ai-gateway": "AI Gateway",
+        "evolink": "EvoLink",
         "kilocode": "Kilo Code",
         "alibaba": "Alibaba Cloud (DashScope)",
         "huggingface": "Hugging Face",
@@ -886,6 +887,7 @@ def cmd_model(args):
         ("opencode-zen", "OpenCode Zen (35+ curated models, pay-as-you-go)"),
         ("opencode-go", "OpenCode Go (open models, $10/month subscription)"),
         ("ai-gateway", "AI Gateway (Vercel — 200+ models, pay-per-use)"),
+        ("evolink", "EvoLink (OpenAI-compatible model gateway)"),
         ("alibaba", "Alibaba Cloud / DashScope Coding (Qwen + multi-provider)"),
         ("huggingface", "Hugging Face Inference Providers (20+ open models)"),
     ]
@@ -960,7 +962,7 @@ def cmd_model(args):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface"):
+    elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "evolink", "alibaba", "huggingface"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
 
@@ -1570,6 +1572,14 @@ _PROVIDER_MODELS = {
         "openai/gpt-5.4",
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",
+    ],
+    "evolink": [
+        "openai/gpt-5.5",
+        "openai/gpt-5.4",
+        "anthropic/claude-opus-4.6",
+        "anthropic/claude-sonnet-4.6",
+        "google/gemini-3-pro-preview",
+        "google/gemini-3-flash",
     ],
     # Curated HF model list — only agentic models that map to OpenRouter defaults.
     # Format: HF model ID → OpenRouter equivalent noted in comment
@@ -3645,7 +3655,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "evolink"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -205,6 +205,14 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "google/gemini-2.5-flash",
         "deepseek/deepseek-v3.2",
     ],
+    "evolink": [
+        "openai/gpt-5.5",
+        "openai/gpt-5.4",
+        "anthropic/claude-opus-4.6",
+        "anthropic/claude-sonnet-4.6",
+        "google/gemini-3-pro-preview",
+        "google/gemini-3-flash",
+    ],
     "kilocode": [
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",
@@ -255,6 +263,7 @@ _PROVIDER_LABELS = {
     "opencode-zen": "OpenCode Zen",
     "opencode-go": "OpenCode Go",
     "ai-gateway": "AI Gateway",
+    "evolink": "EvoLink",
     "kilocode": "Kilo Code",
     "alibaba": "Alibaba Cloud (DashScope)",
     "huggingface": "Hugging Face",
@@ -286,6 +295,9 @@ _PROVIDER_ALIASES = {
     "aigateway": "ai-gateway",
     "vercel": "ai-gateway",
     "vercel-ai-gateway": "ai-gateway",
+    "evo-link": "evolink",
+    "evolink-ai": "evolink",
+    "evolink.ai": "evolink",
     "kilo": "kilocode",
     "kilo-code": "kilocode",
     "kilo-gateway": "kilocode",
@@ -331,7 +343,7 @@ def list_available_providers() -> list[dict[str, str]]:
         "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
         "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
         "opencode-zen", "opencode-go",
-        "ai-gateway", "deepseek", "custom",
+        "ai-gateway", "evolink", "deepseek", "custom",
     ]
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -79,6 +79,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "minimax": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"],
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"],
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
+    "evolink": ["openai/gpt-5.5", "openai/gpt-5.4", "anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "google/gemini-3-pro-preview", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",
@@ -893,6 +894,7 @@ def setup_model_provider(config: dict):
         "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)",
         "GitHub Copilot ACP (spawns `copilot --acp --stdio`)",
         "Hugging Face Inference Providers (20+ open models)",
+        "EvoLink (OpenAI-compatible model gateway)",
     ]
     if keep_label:
         provider_choices.append(keep_label)
@@ -1556,7 +1558,39 @@ def setup_model_provider(config: dict):
         _set_model_provider(config, "huggingface", pconfig.inference_base_url)
         selected_base_url = pconfig.inference_base_url
 
-    # else: provider_idx == 17 (Keep current) — only shown when a provider already exists
+    elif provider_idx == 17:  # EvoLink
+        selected_provider = "evolink"
+        print()
+        print_header("EvoLink API Key")
+        pconfig = PROVIDER_REGISTRY["evolink"]
+        print_info(f"Provider: {pconfig.name}")
+        print_info(f"Base URL: {pconfig.inference_base_url}")
+        print_info("Get your API key at: https://evolink.ai")
+        print()
+
+        existing_key = get_env_value("EVOLINK_API_KEY")
+        if existing_key:
+            print_info(f"Current: {existing_key[:8]}... (configured)")
+            if prompt_yes_no("Update API key?", False):
+                api_key = prompt("  EvoLink API key", password=True)
+                if api_key:
+                    save_env_value("EVOLINK_API_KEY", api_key)
+                    print_success("EvoLink API key updated")
+        else:
+            api_key = prompt("  EvoLink API key", password=True)
+            if api_key:
+                save_env_value("EVOLINK_API_KEY", api_key)
+                print_success("EvoLink API key saved")
+            else:
+                print_warning("Skipped - agent won't work without an API key")
+
+        if existing_custom:
+            save_env_value("OPENAI_BASE_URL", "")
+            save_env_value("OPENAI_API_KEY", "")
+        _set_model_provider(config, "evolink", pconfig.inference_base_url)
+        selected_base_url = pconfig.inference_base_url
+
+    # else: provider_idx == 18 (Keep current) — only shown when a provider already exists
     # Normalize "keep current" to an explicit provider so downstream logic
     # doesn't fall back to the generic OpenRouter/static-model path.
     if selected_provider is None:
@@ -1596,6 +1630,7 @@ def setup_model_provider(config: dict):
             "minimax-cn": "MiniMax CN",
             "anthropic": "Anthropic",
             "ai-gateway": "AI Gateway",
+            "evolink": "EvoLink",
             "custom": "your custom endpoint",
         }
         _prov_display = _prov_names.get(selected_provider, selected_provider or "your provider")
@@ -1737,7 +1772,7 @@ def setup_model_provider(config: dict):
             model_cfg = _model_config_dict(config)
             model_cfg["api_mode"] = "chat_completions"
             config["model"] = model_cfg
-        elif selected_provider in ("copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "ai-gateway", "opencode-zen", "opencode-go", "alibaba"):
+        elif selected_provider in ("copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "ai-gateway", "evolink", "opencode-zen", "opencode-go", "alibaba"):
             _setup_provider_model_selection(
                 config, selected_provider, current_model,
                 prompt_choice, prompt,
@@ -1798,7 +1833,7 @@ def setup_model_provider(config: dict):
     # Write provider+base_url to config.yaml only after model selection is complete.
     # This prevents a race condition where the gateway picks up a new provider
     # before the model name has been updated to match.
-    if selected_provider in ("copilot-acp", "copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic") and selected_base_url is not None:
+    if selected_provider in ("copilot-acp", "copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "evolink", "anthropic") and selected_base_url is not None:
         _update_config_for_provider(selected_provider, selected_base_url)
 
     save_config(config)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -119,6 +119,7 @@ def show_status(args):
         "Kimi": "KIMI_API_KEY",
         "MiniMax": "MINIMAX_API_KEY",
         "MiniMax-CN": "MINIMAX_CN_API_KEY",
+        "EvoLink": "EVOLINK_API_KEY",
         "Firecrawl": "FIRECRAWL_API_KEY",
         "Tavily": "TAVILY_API_KEY",
         "Browserbase": "BROWSERBASE_API_KEY",  # Optional — local browser works without this
@@ -197,6 +198,7 @@ def show_status(args):
         "Kimi / Moonshot":  ("KIMI_API_KEY",),
         "MiniMax":          ("MINIMAX_API_KEY",),
         "MiniMax (China)":  ("MINIMAX_CN_API_KEY",),
+        "EvoLink":          ("EVOLINK_API_KEY",),
     }
     for pname, env_vars in apikey_providers.items():
         key_val = ""

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -28,6 +28,7 @@ def _clean_env(monkeypatch):
         "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY",
         "OPENAI_MODEL", "LLM_MODEL", "NOUS_INFERENCE_BASE_URL",
         "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
+        "EVOLINK_API_KEY", "EVOLINK_BASE_URL",
         # Per-task provider/model/direct-endpoint overrides
         "AUXILIARY_VISION_PROVIDER", "AUXILIARY_VISION_MODEL",
         "AUXILIARY_VISION_BASE_URL", "AUXILIARY_VISION_API_KEY",
@@ -430,6 +431,15 @@ class TestExplicitProviderRouting:
             mock_openai.return_value = MagicMock()
             client, model = resolve_provider_client("deepseek")
             assert client is not None
+
+    def test_explicit_evolink(self, monkeypatch):
+        """provider='evolink' should use EVOLINK_API_KEY."""
+        monkeypatch.setenv("EVOLINK_API_KEY", "evolink-test-key")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = resolve_provider_client("evolink")
+            assert client is not None
+            assert model == "google/gemini-3-flash"
 
     def test_explicit_zai(self, monkeypatch):
         """provider='zai' should use GLM_API_KEY."""

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -177,6 +177,9 @@ class TestProviderModelIds:
     def test_zai_returns_glm_models(self):
         assert "glm-5" in provider_model_ids("zai")
 
+    def test_evolink_returns_curated_models(self):
+        assert "openai/gpt-5.4" in provider_model_ids("evolink")
+
     def test_copilot_prefers_live_catalog(self):
         with patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "gh-token"}), \
              patch("hermes_cli.models._fetch_github_models", return_value=["gpt-5.4", "claude-sonnet-4.6"]):

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -44,6 +44,7 @@ class TestProviderRegistry:
         ("minimax", "MiniMax", "api_key"),
         ("minimax-cn", "MiniMax (China)", "api_key"),
         ("ai-gateway", "AI Gateway", "api_key"),
+        ("evolink", "EvoLink", "api_key"),
         ("kilocode", "Kilo Code", "api_key"),
     ])
     def test_provider_registered(self, provider_id, name, auth_type):
@@ -83,6 +84,11 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("AI_GATEWAY_API_KEY",)
         assert pconfig.base_url_env_var == "AI_GATEWAY_BASE_URL"
 
+    def test_evolink_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["evolink"]
+        assert pconfig.api_key_env_vars == ("EVOLINK_API_KEY",)
+        assert pconfig.base_url_env_var == "EVOLINK_BASE_URL"
+
     def test_kilocode_env_vars(self):
         pconfig = PROVIDER_REGISTRY["kilocode"]
         assert pconfig.api_key_env_vars == ("KILOCODE_API_KEY",)
@@ -101,6 +107,7 @@ class TestProviderRegistry:
         assert PROVIDER_REGISTRY["minimax"].inference_base_url == "https://api.minimax.io/anthropic"
         assert PROVIDER_REGISTRY["minimax-cn"].inference_base_url == "https://api.minimaxi.com/anthropic"
         assert PROVIDER_REGISTRY["ai-gateway"].inference_base_url == "https://ai-gateway.vercel.sh/v1"
+        assert PROVIDER_REGISTRY["evolink"].inference_base_url == "https://api.evolink.ai/v1"
         assert PROVIDER_REGISTRY["kilocode"].inference_base_url == "https://api.kilo.ai/api/gateway"
         assert PROVIDER_REGISTRY["huggingface"].inference_base_url == "https://router.huggingface.co/v1"
 
@@ -122,6 +129,7 @@ PROVIDER_ENV_VARS = (
     "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
     "KIMI_API_KEY", "KIMI_BASE_URL", "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
     "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL",
+    "EVOLINK_API_KEY", "EVOLINK_BASE_URL",
     "KILOCODE_API_KEY", "KILOCODE_BASE_URL",
     "DASHSCOPE_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
     "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN",
@@ -155,6 +163,9 @@ class TestResolveProvider:
     def test_explicit_ai_gateway(self):
         assert resolve_provider("ai-gateway") == "ai-gateway"
 
+    def test_explicit_evolink(self):
+        assert resolve_provider("evolink") == "evolink"
+
     def test_alias_glm(self):
         assert resolve_provider("glm") == "zai"
 
@@ -178,6 +189,11 @@ class TestResolveProvider:
 
     def test_alias_vercel(self):
         assert resolve_provider("vercel") == "ai-gateway"
+
+    def test_alias_evolink(self):
+        assert resolve_provider("evo-link") == "evolink"
+        assert resolve_provider("evolink-ai") == "evolink"
+        assert resolve_provider("evolink.ai") == "evolink"
 
     def test_explicit_kilocode(self):
         assert resolve_provider("kilocode") == "kilocode"
@@ -249,6 +265,10 @@ class TestResolveProvider:
     def test_auto_detects_ai_gateway_key(self, monkeypatch):
         monkeypatch.setenv("AI_GATEWAY_API_KEY", "test-gw-key")
         assert resolve_provider("auto") == "ai-gateway"
+
+    def test_auto_detects_evolink_key(self, monkeypatch):
+        monkeypatch.setenv("EVOLINK_API_KEY", "test-evolink-key")
+        assert resolve_provider("auto") == "evolink"
 
     def test_auto_detects_kilocode_key(self, monkeypatch):
         monkeypatch.setenv("KILOCODE_API_KEY", "test-kilo-key")
@@ -439,6 +459,19 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["api_key"] == "gw-secret-key"
         assert creds["base_url"] == "https://ai-gateway.vercel.sh/v1"
 
+    def test_resolve_evolink_with_key(self, monkeypatch):
+        monkeypatch.setenv("EVOLINK_API_KEY", "evolink-secret-key")
+        creds = resolve_api_key_provider_credentials("evolink")
+        assert creds["provider"] == "evolink"
+        assert creds["api_key"] == "evolink-secret-key"
+        assert creds["base_url"] == "https://api.evolink.ai/v1"
+
+    def test_resolve_evolink_custom_base_url(self, monkeypatch):
+        monkeypatch.setenv("EVOLINK_API_KEY", "evolink-key")
+        monkeypatch.setenv("EVOLINK_BASE_URL", "https://custom.evolink.example/v1")
+        creds = resolve_api_key_provider_credentials("evolink")
+        assert creds["base_url"] == "https://custom.evolink.example/v1"
+
     def test_resolve_kilocode_with_key(self, monkeypatch):
         monkeypatch.setenv("KILOCODE_API_KEY", "kilo-secret-key")
         creds = resolve_api_key_provider_credentials("kilocode")
@@ -521,6 +554,15 @@ class TestRuntimeProviderResolution:
         assert result["api_mode"] == "chat_completions"
         assert result["api_key"] == "gw-key"
         assert "ai-gateway.vercel.sh" in result["base_url"]
+
+    def test_runtime_evolink(self, monkeypatch):
+        monkeypatch.setenv("EVOLINK_API_KEY", "evolink-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="evolink")
+        assert result["provider"] == "evolink"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "evolink-key"
+        assert result["base_url"] == "https://api.evolink.ai/v1"
 
     def test_runtime_kilocode(self, monkeypatch):
         monkeypatch.setenv("KILOCODE_API_KEY", "kilo-key")

--- a/tests/test_fallback_model.py
+++ b/tests/test_fallback_model.py
@@ -358,6 +358,7 @@ class TestProviderCredentials:
         ("kimi-coding", "KIMI_API_KEY", "moonshot.ai"),
         ("minimax", "MINIMAX_API_KEY", "minimax.io"),
         ("minimax-cn", "MINIMAX_CN_API_KEY", "minimaxi.com"),
+        ("evolink", "EVOLINK_API_KEY", "evolink.ai"),
     ])
     def test_provider_resolves(self, provider, env_var, base_url_fragment):
         agent = _make_agent(


### PR DESCRIPTION
## Summary
- register EvoLink as an OpenAI-compatible API-key provider
- expose EvoLink in CLI model/setup, status, doctor, config examples, and model metadata
- add provider resolution, runtime, auxiliary-client, and fallback-model test coverage

## Validation
- `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy /tmp/portable-hermes-agent-pr-venv/bin/python -m pytest tests/test_api_key_providers.py tests/hermes_cli/test_model_validation.py tests/agent/test_auxiliary_client.py tests/test_fallback_model.py`
- 285 passed, 30 warnings

Note: proxy env vars were cleared during validation because the local machine has a SOCKS proxy configured and this project does not install `httpx[socks]` by default.