### PR TITLE
ci: skip optional Vercel deploy without hook

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -42,8 +42,23 @@ jobs:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
+      - name: Check Vercel deploy hook
+        id: vercel
+        env:
+          VERCEL_DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$VERCEL_DEPLOY_HOOK" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::VERCEL_DEPLOY_HOOK is not configured; skipping optional Vercel deploy."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Trigger Vercel Deploy
-        run: curl -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"
+        if: steps.vercel.outputs.configured == 'true'
+        env:
+          VERCEL_DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}
+        run: curl -fsS -X POST "$VERCEL_DEPLOY_HOOK"
 
   deploy-docs:
     if: github.repository == 'NousResearch/hermes-agent'


### PR DESCRIPTION
## Summary
- Treat `VERCEL_DEPLOY_HOOK` as optional for release/workflow-dispatch deploys.
- Skip the Vercel curl cleanly when the secret is not configured.
- Keep real Vercel deploy failures fatal by using `curl -fsS` when the hook exists.

Fixes the release-triggered `Deploy Site / deploy-vercel` failure from run 28525348182, where the fork executed `curl -X POST ""`.

## Validation
- `git diff --check`
- Inspected failed release log for job 84560170538
