### PR TITLE
[codex] fix installer web requests

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -42,7 +42,7 @@ echo [STEP 1/10] Downloading Python %PYTHON_VERSION% embedded...
 powershell -NoProfile -ExecutionPolicy Bypass -Command ^
     "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;" ^
     "$ProgressPreference = 'SilentlyContinue';" ^
-    "Invoke-WebRequest -Uri '%PYTHON_URL%' -OutFile '%PYTHON_ZIP%'"
+    "Invoke-WebRequest -Uri '%PYTHON_URL%' -OutFile '%PYTHON_ZIP%' -UseBasicParsing -ErrorAction Stop"
 
 if not exist "%PYTHON_ZIP%" (
     echo ERROR: Failed to download Python. Check your internet connection.
@@ -90,7 +90,7 @@ if %errorlevel% neq 0 (
     powershell -NoProfile -ExecutionPolicy Bypass -Command ^
         "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;" ^
         "$ProgressPreference = 'SilentlyContinue';" ^
-        "Invoke-WebRequest -Uri 'https://bootstrap.pypa.io/get-pip.py' -OutFile '%PYTHON_DIR%\get-pip.py'"
+        "Invoke-WebRequest -Uri 'https://bootstrap.pypa.io/get-pip.py' -OutFile '%PYTHON_DIR%\get-pip.py' -UseBasicParsing -ErrorAction Stop"
     "%PYTHON_EXE%" "%PYTHON_DIR%\get-pip.py" --quiet
     if errorlevel 1 (
         echo ERROR: Failed to install pip.
@@ -118,8 +118,9 @@ if not exist "%PYTHON_DIR%\Lib\tkinter" (
     set "TCLTK_TEMP=%SCRIPT_DIR%_tcltk_temp"
 
     powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+        "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;" ^
         "$ProgressPreference = 'SilentlyContinue';" ^
-        "Invoke-WebRequest -Uri '%TCLTK_URL%' -OutFile '%TCLTK_MSI%'"
+        "Invoke-WebRequest -Uri '%TCLTK_URL%' -OutFile '%TCLTK_MSI%' -UseBasicParsing -ErrorAction Stop"
 
     if exist "!TCLTK_MSI!" (
         :: Use PowerShell Start-Process -Wait for reliable synchronous extraction.

--- a/tests/test_install_bat.py
+++ b/tests/test_install_bat.py
@@ -1,0 +1,25 @@
+"""Regression tests for the root Windows batch installer."""
+
+from pathlib import Path
+
+
+_INSTALL_BAT = Path(__file__).resolve().parents[1] / "install.bat"
+
+
+def test_install_bat_downloads_use_basic_parsing_and_stop_on_errors():
+    """Windows PowerShell 5.1 can prompt without -UseBasicParsing.
+
+    That prompt blocks non-technical users during first-run setup and was
+    reported in issue #27 while downloading the Tcl/Tk MSI.
+    """
+    source = _INSTALL_BAT.read_text(encoding="utf-8")
+    download_lines = [
+        line.strip()
+        for line in source.splitlines()
+        if "Invoke-WebRequest" in line and "-OutFile" in line
+    ]
+
+    assert download_lines, "expected install.bat to contain download commands"
+    for line in download_lines:
+        assert "-UseBasicParsing" in line, line
+        assert "-ErrorAction Stop" in line, line


### PR DESCRIPTION
## Summary
- add `-UseBasicParsing -ErrorAction Stop` to every root `install.bat` download
- add TLS 1.2 setup to the Tcl/Tk MSI download path
- add a regression test so future batch-installer downloads cannot omit the Windows PowerShell-safe flags

## Root Cause
Issue #27 shows Windows PowerShell 5.1 prompting during `Invoke-WebRequest` at the Tkinter/Tcl/Tk download step. Without `-UseBasicParsing`, Windows PowerShell can stop for the legacy script execution warning instead of downloading the file, so the installer falls through to `[WARN] Could not download Tkinter - GUI may not work.`

Fixes #27.

## Validation
- `E:\hermes\venv\Scripts\python.exe -m pytest tests\test_install_bat.py -q`
- `git diff --check`