### PR TITLE
[codex] Guard portable upstream remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Or run:
 hermes.bat update --backup --yes
 ```
 
-Updates come from `aivrar/portable-hermes-agent`. Runtime folders such as `.hermes/`, `.hermes/custom_tools/`, `.hermes/extensions/`, `extensions/`, and `python_embedded/` are preserved. Upstream Hermes changes from NousResearch are included only after this portable repo has merged, tested, and released them.
+Updates come from `aivrar/portable-hermes-agent`, the tested portable distribution. Runtime folders such as `.hermes/`, `.hermes/custom_tools/`, `.hermes/extensions/`, `extensions/`, and `python_embedded/` are preserved. Raw upstream Hermes changes from `NousResearch/hermes-agent` are not pulled directly into user installs; they are included after this portable repo has merged, tested, and released them.
 
 ### 4. Connect an AI Model
 

--- a/docs/hermes-guide.md
+++ b/docs/hermes-guide.md
@@ -884,8 +884,8 @@ See Part 5 for complete details on all 10 LM Studio tools.
 
 | Tool | What It Does | Requirements |
 |------|-------------|-------------|
-| **update_hermes** | Run the safe portable update flow from this repo | None |
-| **check_hermes_updates** | Check if portable repo updates are available | None |
+| **update_hermes** | Run the safe portable distribution update from `aivrar/portable-hermes-agent` | None |
+| **check_hermes_updates** | Check if portable distribution updates are available | None |
 | **search_guide** | Search this user guide | None |
 
 ### Messaging Tools

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6654,6 +6654,28 @@ OFFICIAL_REPO_URL = "https://github.com/aivrar/portable-hermes-agent.git"
 SKIP_UPSTREAM_PROMPT_FILE = ".skip_upstream_prompt"
 
 
+def _normalize_repo_url(url: Optional[str]) -> str:
+    """Normalize common GitHub remote URL forms for policy comparisons."""
+    if not url:
+        return ""
+    lower = url.strip().rstrip("/").lower()
+    if lower.endswith(".git"):
+        lower = lower[:-4]
+    if lower.startswith("git@github.com:"):
+        lower = "https://github.com/" + lower[len("git@github.com:") :]
+    elif lower.startswith("ssh://git@github.com/"):
+        lower = "https://github.com/" + lower[len("ssh://git@github.com/") :]
+    return lower
+
+
+def _is_official_repo_url(url: Optional[str]) -> bool:
+    """Return True only for the tested portable distribution repository."""
+    normalized = _normalize_repo_url(url)
+    return bool(normalized) and normalized in {
+        _normalize_repo_url(official) for official in OFFICIAL_REPO_URLS
+    }
+
+
 def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
     """Get the URL of the origin remote, or None if not set."""
     try:
@@ -6674,17 +6696,7 @@ def _is_fork(origin_url: Optional[str]) -> bool:
     """Check if the origin remote points to a fork (not the official repo)."""
     if not origin_url:
         return False
-    # Normalize URL for comparison (strip trailing .git if present)
-    normalized = origin_url.rstrip("/")
-    if normalized.endswith(".git"):
-        normalized = normalized[:-4]
-    for official in OFFICIAL_REPO_URLS:
-        official_normalized = official.rstrip("/")
-        if official_normalized.endswith(".git"):
-            official_normalized = official_normalized[:-4]
-        if normalized == official_normalized:
-            return False
-    return True
+    return not _is_official_repo_url(origin_url)
 
 
 def _has_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
@@ -6699,6 +6711,22 @@ def _has_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
         return result.returncode == 0
     except Exception:
         return False
+
+
+def _get_upstream_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
+    """Get the URL of the upstream remote, or None if not set."""
+    try:
+        result = subprocess.run(
+            git_cmd + ["remote", "get-url", "upstream"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
 
 
 def _add_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
@@ -6770,6 +6798,7 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
 
     This implements the fork upstream sync logic:
     - If upstream remote doesn't exist, ask user if they want to add it
+    - If upstream exists, require it to be this portable distribution repo
     - Compare origin/main with upstream/main
     - If origin/main is strictly behind upstream/main, pull from upstream
     - Try to sync fork back to origin if possible
@@ -6783,7 +6812,7 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
 
         # Ask user if they want to add upstream
         print()
-        print("ℹ Your fork is not tracking the official Hermes repository.")
+        print("ℹ Your fork is not tracking the official Portable Hermes Agent repository.")
         print("  This means you may miss Portable Hermes Agent updates.")
         print()
         try:
@@ -6809,6 +6838,19 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
                 f"  Skipped. Run 'git remote add upstream {OFFICIAL_REPO_URL}' to add later."
             )
             _mark_skip_upstream_prompt()
+            return
+    else:
+        upstream_url = _get_upstream_url(git_cmd, cwd)
+        if not _is_official_repo_url(upstream_url):
+            print()
+            print("! Existing upstream remote is not Portable Hermes Agent.")
+            if upstream_url:
+                print(f"  upstream: {upstream_url}")
+            print(f"  expected: {OFFICIAL_REPO_URL}")
+            print(
+                "  Skipping fork sync so this portable install is not updated "
+                "from an untested source."
+            )
             return
 
     # Fetch upstream main only. This sync compares upstream/main with

--- a/tests/hermes_cli/test_update_remote_policy.py
+++ b/tests/hermes_cli/test_update_remote_policy.py
@@ -1,0 +1,66 @@
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from hermes_cli import main as hm
+
+
+def test_official_repo_url_policy_accepts_portable_forms():
+    assert hm._is_official_repo_url(
+        "https://github.com/aivrar/portable-hermes-agent.git"
+    )
+    assert hm._is_official_repo_url(
+        "git@github.com:aivrar/portable-hermes-agent.git"
+    )
+    assert hm._is_fork("https://github.com/NousResearch/hermes-agent.git")
+
+
+def test_sync_with_upstream_skips_nonportable_existing_upstream(capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["git", "remote", "get-url", "upstream"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="https://github.com/NousResearch/hermes-agent.git\n",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    with patch.object(hm.subprocess, "run", side_effect=fake_run):
+        hm._sync_with_upstream_if_needed(["git"], Path("unused"))
+
+    out = capsys.readouterr().out
+    assert "not Portable Hermes Agent" in out
+    assert "https://github.com/NousResearch/hermes-agent.git" in out
+    assert not any(cmd[:3] == ["git", "fetch", "upstream"] for cmd in calls)
+
+
+def test_sync_with_upstream_fetches_official_portable_upstream(capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["git", "remote", "get-url", "upstream"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="https://github.com/aivrar/portable-hermes-agent.git\n",
+                stderr="",
+            )
+        if cmd == ["git", "fetch", "upstream", "main", "--quiet"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd == ["git", "rev-list", "--count", "upstream/main..origin/main"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="0\n", stderr="")
+        if cmd == ["git", "rev-list", "--count", "origin/main..upstream/main"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="0\n", stderr="")
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    with patch.object(hm.subprocess, "run", side_effect=fake_run):
+        hm._sync_with_upstream_if_needed(["git"], Path("unused"))
+
+    out = capsys.readouterr().out
+    assert "Fork is up to date with upstream" in out
+    assert ["git", "fetch", "upstream", "main", "--quiet"] in calls

--- a/tools/update_hermes_tool.py
+++ b/tools/update_hermes_tool.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """
-Portable Hermes update tools.
+Portable Hermes distribution update tools.
 
 These tools intentionally update from the user's configured ``origin`` remote.
 For portable-hermes-agent, ``origin`` should be
-``https://github.com/aivrar/portable-hermes-agent.git``.  Do not merge the
-upstream Hermes repository directly from a model-visible tool: upstream changes
-are incorporated by maintainers, tested with the portable extensions, and then
-shipped through this portable repo.
+``https://github.com/aivrar/portable-hermes-agent.git``. This updates the
+portable distribution, not raw ``NousResearch/hermes-agent``. Upstream Hermes
+changes are incorporated by maintainers, tested with the portable extensions,
+and then shipped through this portable repo.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What changed

- Hardened `hermes update` fork-sync logic so an existing `upstream` remote must point to `aivrar/portable-hermes-agent` before the portable updater fetches from it.
- Added canonical remote URL handling for HTTPS, SSH, and `.git` variants.
- Clarified docs and the model-visible update tool description: `update_hermes` updates the tested portable distribution, not raw `NousResearch/hermes-agent`.
- Added regression tests for stale/non-portable `upstream` remotes.

## Why

The portable update path had been redirected to the tested portable repo, but inherited fork-sync code would still trust any existing `upstream` remote. In a checkout where `upstream` points to `NousResearch/hermes-agent`, the fork-sync branch could fetch from the raw upstream repo instead of the portable distribution. That is unsafe for user installs because portable-only runtime/tool preservation has to be merged and tested before release.

## Validation

- `pytest tests\hermes_cli\test_update_remote_policy.py tests\tools\test_update_hermes_tool.py tests\hermes_cli\test_cmd_update.py::TestCmdUpdateBranchFallback::test_update_on_fork_checks_upstream_when_origin_up_to_date -q`
- `python -m py_compile hermes_cli\main.py tools\update_hermes_tool.py`
- `git diff --check`