### PR TITLE
[codex] Package tracked files only for releases

### DIFF
--- a/build_release.py
+++ b/build_release.py
@@ -1,6 +1,7 @@
 """Build a release zip for portable-hermes-agent."""
 import argparse
 import os
+import subprocess
 import zipfile
 
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
@@ -33,6 +34,7 @@ EXCLUDE_PATHS = {
     ".env",
     "build_release.py",
     "test_script.sh",
+    "test.pdf",
     "smoke_test_all_tools.py",
     "test_all_tools.py",
     "agent_debug.log",
@@ -97,6 +99,39 @@ def should_exclude(rel_path):
     return False
 
 
+def iter_release_files():
+    """Yield release candidate files.
+
+    Prefer git's tracked-file list so ignored local scratch files in a
+    maintainer checkout cannot leak into a published portable ZIP. Fall back to
+    a worktree walk when this script is run outside a git checkout.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        yield from iter_worktree_files()
+        return
+
+    for rel_path in result.stdout.decode("utf-8", errors="surrogateescape").split("\0"):
+        if rel_path:
+            yield rel_path
+
+
+def iter_worktree_files():
+    """Fallback file walk for source trees without git metadata."""
+    for root, dirs, files in os.walk(PROJECT_ROOT):
+        # Prune excluded dirs in-place to avoid walking into them
+        dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
+
+        for fname in sorted(files):
+            yield os.path.relpath(os.path.join(root, fname), PROJECT_ROOT)
+
+
 def main():
     args = parse_args()
     version = args.version[1:] if args.version.startswith("v") else args.version
@@ -115,23 +150,20 @@ def main():
     prefix = "portable-hermes-agent"
 
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED, compresslevel=9) as zf:
-        for root, dirs, files in os.walk(PROJECT_ROOT):
-            # Prune excluded dirs in-place to avoid walking into them
-            dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
+        for rel_path in sorted(iter_release_files()):
+            if should_exclude(rel_path):
+                continue
 
-            for fname in sorted(files):
-                full_path = os.path.join(root, fname)
-                rel_path = os.path.relpath(full_path, PROJECT_ROOT)
+            full_path = os.path.join(PROJECT_ROOT, rel_path)
+            if not os.path.isfile(full_path):
+                continue
 
-                if should_exclude(rel_path):
-                    continue
-
-                archive_name = os.path.join(prefix, rel_path).replace("\\", "/")
-                try:
-                    zf.write(full_path, archive_name)
-                    count += 1
-                except (PermissionError, OSError):
-                    pass
+            archive_name = os.path.join(prefix, rel_path).replace("\\", "/")
+            try:
+                zf.write(full_path, archive_name)
+                count += 1
+            except (PermissionError, OSError):
+                pass
 
     size_mb = os.path.getsize(zip_path) / (1024 * 1024)
     print(f"Done! {count} files, {size_mb:.1f} MB")

--- a/tests/test_build_release.py
+++ b/tests/test_build_release.py
@@ -1,4 +1,5 @@
 import build_release
+import subprocess
 
 
 def test_release_zip_includes_user_launchers_and_docs():
@@ -12,6 +13,7 @@ def test_release_zip_excludes_development_only_dirs():
     assert build_release.should_exclude(".github/workflows/tests.yml") is True
     assert build_release.should_exclude("tests/test_toolsets.py") is True
     assert build_release.should_exclude(".pytest_cache/v/cache/nodeids") is True
+    assert build_release.should_exclude("test.pdf") is True
 
 
 def test_release_zip_excludes_portable_runtime_dirs():
@@ -19,3 +21,31 @@ def test_release_zip_excludes_portable_runtime_dirs():
     assert build_release.should_exclude("python_embedded/python.exe") is True
     assert build_release.should_exclude("extensions/comfyui/README.md") is True
     assert build_release.should_exclude("extensions\\music-server\\README.md") is True
+
+
+def test_release_files_prefer_git_tracked_list(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        assert cmd == ["git", "ls-files", "-z"]
+        return subprocess.CompletedProcess(cmd, 0, stdout=b"README.md\0START.bat\0")
+
+    def fail_worktree_walk():
+        raise AssertionError("ignored worktree files should not be walked")
+
+    monkeypatch.setattr(build_release.subprocess, "run", fake_run)
+    monkeypatch.setattr(build_release, "iter_worktree_files", fail_worktree_walk)
+
+    assert list(build_release.iter_release_files()) == ["README.md", "START.bat"]
+
+
+def test_release_files_fall_back_without_git(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise subprocess.CalledProcessError(128, cmd)
+
+    monkeypatch.setattr(build_release.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        build_release,
+        "iter_worktree_files",
+        lambda: iter(["README.md", "START.bat"]),
+    )
+
+    assert list(build_release.iter_release_files()) == ["README.md", "START.bat"]


### PR DESCRIPTION
## What changed

- Updated `build_release.py` to package files from `git ls-files` when git metadata is available.
- Kept the existing worktree-walk fallback for source trees without `.git`.
- Added `test.pdf` to explicit fallback excludes.
- Added tests covering tracked-file packaging and non-git fallback behavior.

## Why

The release builder walked the entire local working tree. Ignored local scratch files, such as a root `test.pdf`, could be included in a portable release ZIP even though they are not part of the repository. Release artifacts should come from tracked source files plus the existing explicit excludes, not from whatever happens to be present in a maintainer checkout.

## Validation

- `pytest tests\test_build_release.py tests\hermes_cli\test_update_remote_policy.py tests\tools\test_update_hermes_tool.py -q`
- `python -m py_compile build_release.py hermes_cli\main.py tools\update_hermes_tool.py`
- `git diff --check`