### PR TITLE
[codex] fix Windows hidden-search test collection

### DIFF
--- a/tests/tools/test_search_hidden_dirs.py
+++ b/tests/tools/test_search_hidden_dirs.py
@@ -13,6 +13,8 @@ Fix: _search_files (find) and _search_with_grep both now exclude hidden
 directories, matching ripgrep's default behavior.
 """
 
+import os
+import shutil
 import subprocess
 
 import pytest
@@ -41,6 +43,7 @@ def searchable_tree(tmp_path):
     return tmp_path / "skills"
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX find syntax is not available on Windows")
 class TestFindExcludesHiddenDirs:
     """_search_files uses find, which should exclude hidden directories."""
 
@@ -71,6 +74,7 @@ class TestFindExcludesHiddenDirs:
         assert "SKILL.md" in result.stdout
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX grep syntax is not available on Windows")
 class TestGrepExcludesHiddenDirs:
     """_search_with_grep should exclude hidden directories."""
 
@@ -97,7 +101,7 @@ class TestRipgrepAlreadyExcludesHidden:
     """Verify ripgrep's default behavior is to skip hidden directories."""
 
     @pytest.mark.skipif(
-        subprocess.run(["which", "rg"], capture_output=True).returncode != 0,
+        shutil.which("rg") is None,
         reason="ripgrep not installed",
     )
     def test_rg_skips_hub_by_default(self, searchable_tree):
@@ -110,7 +114,7 @@ class TestRipgrepAlreadyExcludesHidden:
         assert "catalog.json" not in result.stdout
 
     @pytest.mark.skipif(
-        subprocess.run(["which", "rg"], capture_output=True).returncode != 0,
+        shutil.which("rg") is None,
         reason="ripgrep not installed",
     )
     def test_rg_finds_visible_content(self, searchable_tree):


### PR DESCRIPTION
﻿## Summary
- replace Unix-only `which rg` detection with Python `shutil.which`
- skip POSIX `find`/`grep` backend tests on Windows instead of failing during collection

## Why
During the full audit, `tests/tools/test_search_hidden_dirs.py` failed at import time on Windows because `which` is not available under PowerShell/cmd. The same file also runs POSIX shell `find` and `grep` syntax that is not valid on native Windows.

## Validation
- `venv\\Scripts\\python.exe -m pytest tests\\tools\\test_search_hidden_dirs.py -q` → 4 passed, 5 skipped
- `venv\\Scripts\\python.exe -m pytest tests\\tools\\test_update_hermes_tool.py tests\\test_install_bat.py tests\\test_build_release.py tests\\hermes_cli\\test_update_remote_policy.py tests\\tools\\test_search_hidden_dirs.py -q` → 21 passed, 5 skipped
- `venv\\Scripts\\python.exe -m pytest --collect-only -q` → 37,267 collected / 25 deselected after refreshing declared dev + ACP dependencies
- `venv\\Scripts\\python.exe -m ruff check tests\\tools\\test_search_hidden_dirs.py tools\\update_hermes_tool.py build_release.py`
