### PR TITLE
[codex] clarify Hermes updater docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Built on [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agen
 | **Guide** | 1 | Searchable built-in user manual |
 | **GPU** | 1 | NVIDIA GPU status (memory, temp, utilization) |
 | **Model Switcher** | 1 | Switch between cloud and local AI models |
-| **Hermes Update** | 2 | Update from this portable repo with backups and runtime preservation |
+| **Hermes Update** | 2 | Update upstream Hermes while preserving portable tools, extensions, and runtime data |
 
 Plus all built-in hermes-agent tools: web search, file operations, browser automation, code execution, delegation, memory, skills, messaging, Home Assistant, and more.
 

--- a/docs/Portable-Hermes-Agent-Manual.html
+++ b/docs/Portable-Hermes-Agent-Manual.html
@@ -1516,12 +1516,12 @@ Say: "Generate a 1024x768 image of a cyberpunk city at night, 30 steps, high det
 <tbody>
 <tr>
 <td><strong>update_hermes</strong></td>
-<td>Run the safe portable update flow from this repo</td>
+<td>Update upstream Hermes from NousResearch while preserving Portable Hermes tools/extensions</td>
 <td>None</td>
 </tr>
 <tr>
 <td><strong>check_hermes_updates</strong></td>
-<td>Check if portable repo updates are available</td>
+<td>Check whether upstream Hermes updates are available</td>
 <td>None</td>
 </tr>
 <tr>


### PR DESCRIPTION
﻿## Summary
- clarify that `update_hermes` updates upstream Hermes from NousResearch
- keep the README/manual distinction between Portable Hermes distribution updates and upstream Hermes updates aligned

## Validation
- `git diff --check`
- searched for the stale updater wording
