### PR TITLE
[codex] fix ignore-user-config CI test isolation

### DIFF
--- a/tests/hermes_cli/test_ignore_user_config_flags.py
+++ b/tests/hermes_cli/test_ignore_user_config_flags.py
@@ -32,11 +32,15 @@ def _clean_env(monkeypatch):
     those writes aren't tracked by monkeypatch and won't be undone by it.
     We add explicit cleanup on yield to prevent cross-test pollution.
     """
-    for var in ("HERMES_IGNORE_USER_CONFIG", "HERMES_IGNORE_RULES"):
+    for var in ("HERMES_IGNORE_USER_CONFIG", "HERMES_IGNORE_RULES", "HERMES_MANAGED_DIR"):
         monkeypatch.delenv(var, raising=False)
+    from hermes_cli import managed_scope
+
+    managed_scope.invalidate_managed_cache()
     yield
-    for var in ("HERMES_IGNORE_USER_CONFIG", "HERMES_IGNORE_RULES"):
+    for var in ("HERMES_IGNORE_USER_CONFIG", "HERMES_IGNORE_RULES", "HERMES_MANAGED_DIR"):
         os.environ.pop(var, None)
+    managed_scope.invalidate_managed_cache()
 
 
 class TestIgnoreUserConfigEnvGate:
@@ -66,13 +70,13 @@ class TestIgnoreUserConfigEnvGate:
         return cli.load_cli_config
 
     def test_user_config_loaded_when_flag_unset(self, tmp_path, monkeypatch):
-        self._write_user_config(tmp_path, "anthropic/claude-sonnet-4.6")
+        self._write_user_config(tmp_path, "user-only/ignore-config-sentinel")
         load_cli_config = self._reload_cli(monkeypatch, tmp_path)
 
         cfg = load_cli_config()
 
         # User config value wins
-        assert cfg["model"]["default"] == "anthropic/claude-sonnet-4.6"
+        assert cfg["model"]["default"] == "user-only/ignore-config-sentinel"
         assert cfg["agent"]["system_prompt"] == "from user config"
 
     def test_user_config_skipped_when_flag_set(self, tmp_path, monkeypatch):
@@ -81,7 +85,8 @@ class TestIgnoreUserConfigEnvGate:
         The built-in default ``model.default`` is empty string (no user override),
         and the user's ``agent.system_prompt`` is not seen.
         """
-        self._write_user_config(tmp_path, "anthropic/claude-sonnet-4.6")
+        user_model = "user-only/ignore-config-sentinel"
+        self._write_user_config(tmp_path, user_model)
         monkeypatch.setenv("HERMES_IGNORE_USER_CONFIG", "1")
 
         load_cli_config = self._reload_cli(monkeypatch, tmp_path)
@@ -93,18 +98,18 @@ class TestIgnoreUserConfigEnvGate:
         # User-set model.default MUST NOT leak through — either the built-in
         # default ("" or unset) or a project-level fallback, but never the
         # user's value
-        assert cfg["model"].get("default", "") != "anthropic/claude-sonnet-4.6"
+        assert cfg["model"].get("default", "") != user_model
 
     def test_flag_ignored_when_set_to_other_value(self, tmp_path, monkeypatch):
         """Only the literal value "1" activates the bypass, matching the yolo pattern."""
-        self._write_user_config(tmp_path, "anthropic/claude-sonnet-4.6")
+        self._write_user_config(tmp_path, "user-only/ignore-config-sentinel")
         monkeypatch.setenv("HERMES_IGNORE_USER_CONFIG", "true")  # not "1"
 
         load_cli_config = self._reload_cli(monkeypatch, tmp_path)
         cfg = load_cli_config()
 
         # "true" != "1", so user config IS loaded
-        assert cfg["model"]["default"] == "anthropic/claude-sonnet-4.6"
+        assert cfg["model"]["default"] == "user-only/ignore-config-sentinel"
 
 
 class TestIgnoreRulesEnvGate:


### PR DESCRIPTION
﻿## Summary
- make the ignore-user-config regression test use a unique user-only sentinel model
- clear `HERMES_MANAGED_DIR` and managed-scope caches in the file-local fixture
- prevents CI managed/project config values from being mistaken for user-config leakage

## Root cause
`test_user_config_skipped_when_flag_set` asserted against a real model string that can also come from project or managed config fallback. On `main` CI, slice 3/8 failed because the resolved fallback matched the test's fake user value, even though the test was meant to prove only that the user `config.yaml` value was skipped.

## Validation
- `venv\\Scripts\\python.exe -m pytest tests\\hermes_cli\\test_ignore_user_config_flags.py -q`
- `venv\\Scripts\\python.exe -m pytest tests\\hermes_cli\\test_managed_scope.py tests\\hermes_cli\\test_managed_scope_cli_config.py tests\\hermes_cli\\test_managed_scope_config.py tests\\hermes_cli\\test_managed_scope_overlay.py -q`
- `venv\\Scripts\\python.exe -m ruff check tests\\hermes_cli\\test_ignore_user_config_flags.py`
- repeated ignore-user-config test with an inherited `HERMES_MANAGED_DIR` containing the CI-like Anthropic model
