### PR TITLE
chore(security): document patched self-package advisory

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "CVE-2026-10222"
+reason = "Version-only match on this repository's own 0.17.0 package metadata; the upstream sanitizer fix and regression tests from commit b944c6e821c2177eac6da857c99ff24566aa56b0 are already present."


### PR DESCRIPTION
## Summary

- add a narrowly scoped OSV exception for CVE-2026-10222
- document that the upstream sanitizer fix and regression tests are already present
- prevent the repository's own stale 0.17.0 package metadata from recreating a false-positive alert

## Validation

- ran OSV Scanner 2.4.0 against all five tracked lockfiles
- confirmed only CVE-2026-10222 and its alias were filtered
- scanner reported no remaining issues
- ran the sanitizer-focused tests: 15 passed