### PR TITLE
fix(deps): remediate remaining JavaScript alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10926,9 +10926,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lodash": "4.18.1",
     "@assistant-ui/store": "0.2.13",
     "yauzl": "^3.3.1",
+    "fast-uri": "3.1.4",
     "js-yaml": "4.3.0",
     "tar": "7.5.20"
   },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9379,9 +9379,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/website/package.json
+++ b/website/package.json
@@ -39,7 +39,7 @@
     "@babel/core": "7.29.7",
     "body-parser": "1.20.6",
     "brace-expansion": "1.1.16",
-    "dompurify": "3.4.11",
+    "dompurify": "3.4.12",
     "http-proxy-middleware": "2.0.10",
     "joi": "17.13.4",
     "launch-editor": "2.14.1",


### PR DESCRIPTION
## Summary

- pin `fast-uri` to 3.1.4 in the root dependency graph
- update the website `dompurify` override to 3.4.12
- regenerate both affected lockfiles with patched integrity metadata

## Why

GitHub reported three remaining Dependabot alerts after the automated security PR queue completed: two high-severity `fast-uri` advisories in the root lockfile and one low-severity `dompurify` advisory in the website lockfile. Dependabot did not open follow-up PRs for these manifest/lockfile pairs.

## Impact

The affected transitive dependencies now resolve to their first patched releases without changing application APIs or runtime configuration.

## Validation

- `npm audit --package-lock-only --audit-level=low` (root): 0 vulnerabilities
- `npm audit --package-lock-only --audit-level=low` (website): 0 vulnerabilities
- `npm ls fast-uri --all`: resolves 3.1.4
- `npm ls dompurify --all` (website): resolves overridden 3.4.12
- desktop TypeScript typecheck: passed
- Docusaurus production build for English and Simplified Chinese: passed
- `git diff --check`: passed

The Docusaurus build retained the repository's existing broken-link and broken-anchor warnings.