### PR TITLE
fix(release): exclude generated docs from portable zip

### DIFF
--- a/build_release.py
+++ b/build_release.py
@@ -42,6 +42,16 @@ EXCLUDE_PATHS = {
     "thinking_debug.log",
 }
 
+# Generated Docusaurus source is published on the documentation site and is
+# not consumed by the portable runtime.  Keeping it in the ZIP duplicates
+# skill instructions (including shell examples) and can trigger download-time
+# antivirus heuristics such as Norton's MD:HttpRequest-inf signature.  Retain
+# website/static/api/model-catalog.json, which the updater uses to seed the
+# local model catalog cache.
+EXCLUDE_PREFIXES = {
+    "website/docs",
+}
+
 # File extensions to exclude
 EXCLUDE_EXTS = {".pyc", ".pyo"}
 
@@ -80,6 +90,12 @@ def should_exclude(rel_path):
     # Check path exclusions
     if norm_path in {path.replace("\\", "/") for path in EXCLUDE_PATHS}:
         return True
+
+    # Check path-prefix exclusions
+    for prefix in EXCLUDE_PREFIXES:
+        norm_prefix = prefix.replace("\\", "/").rstrip("/")
+        if norm_path == norm_prefix or norm_path.startswith(norm_prefix + "/"):
+            return True
 
     # Check extension repos
     for repo in EXCLUDE_EXT_REPOS:

--- a/tests/test_build_release.py
+++ b/tests/test_build_release.py
@@ -16,6 +16,26 @@ def test_release_zip_excludes_development_only_dirs():
     assert build_release.should_exclude("test.pdf") is True
 
 
+def test_release_zip_excludes_generated_docs_but_keeps_runtime_assets():
+    flagged_doc = (
+        "website/docs/user-guide/skills/optional/autonomous-ai-agents/"
+        "autonomous-ai-agents-blackbox.md"
+    )
+    assert build_release.should_exclude(flagged_doc) is True
+    assert build_release.should_exclude(flagged_doc.replace("/", "\\")) is True
+
+    # The portable updater seeds its model cache from this tracked manifest.
+    assert build_release.should_exclude("website/static/api/model-catalog.json") is False
+
+    # Preserve the actual optional skill; only its generated website copy is removed.
+    assert (
+        build_release.should_exclude(
+            "optional-skills/autonomous-ai-agents/blackbox/SKILL.md"
+        )
+        is False
+    )
+
+
 def test_release_zip_excludes_portable_runtime_dirs():
     assert build_release.should_exclude(".hermes/config.yaml") is True
     assert build_release.should_exclude("python_embedded/python.exe") is True


### PR DESCRIPTION
## Summary

- exclude generated `website/docs/**` Docusaurus source from portable release ZIPs
- preserve the actual optional skills and `website/static/api/model-catalog.json` runtime asset
- add Windows- and POSIX-path regression coverage for the release filter

## Why

Fixes #56. Norton blocks the v1.3.6 ZIP on the generated Blackbox skill documentation page with `MD:HttpRequest-inf [Susp]`. The reported file is plain Markdown copied from an optional skill and contains URLs plus shell examples; it is not executed by the installer or runtime. Shipping the generated Docusaurus copy duplicates those instructions and adds unnecessary antivirus scanning surface.

## Impact

Future portable ZIPs omit Docusaurus documentation source while retaining:

- the real Blackbox optional skill
- the runtime model catalog used by `hermes update`
- `START.bat`, `UPDATE.bat`, and `START_HERE.txt`

The live documentation site remains unchanged.

## Validation

- `python -m pytest tests/test_build_release.py -q`: 6 passed
- `python -m ruff check build_release.py tests/test_build_release.py`: passed
- `git diff --check`: passed
- end-to-end test ZIP: 3,677 entries, 54.9 MiB
- `website/docs/**` entries: 0
- reported Blackbox generated page present: false
- real Blackbox optional skill present: true
- runtime model catalog present: true
- portable launchers present: true

Norton is not installed in the validation environment, so its proprietary signature could not be reproduced directly. The available antivirus products are Malwarebytes and Windows Defender.