### PR TITLE
fix(release): exclude localized generated docs

### DIFF
--- a/build_release.py
+++ b/build_release.py
@@ -45,12 +45,14 @@ EXCLUDE_PATHS = {
 # Generated Docusaurus source is published on the documentation site and is
 # not consumed by the portable runtime.  Keeping it in the ZIP duplicates
 # skill instructions (including shell examples) and can trigger download-time
-# antivirus heuristics such as Norton's MD:HttpRequest-inf signature.  Retain
+# antivirus heuristics such as Norton's MD:HttpRequest-inf signature.  This
+# includes localized copies under website/i18n/<locale>/.  Retain
 # website/static/api/model-catalog.json, which the updater uses to seed the
 # local model catalog cache.
 EXCLUDE_PREFIXES = {
     "website/docs",
 }
+I18N_DOCS_PLUGIN_PREFIX = "docusaurus-plugin-content-docs"
 
 # File extensions to exclude
 EXCLUDE_EXTS = {".pyc", ".pyo"}
@@ -96,6 +98,19 @@ def should_exclude(rel_path):
         norm_prefix = prefix.replace("\\", "/").rstrip("/")
         if norm_path == norm_prefix or norm_path.startswith(norm_prefix + "/"):
             return True
+
+    # Docusaurus stores localized docs below a locale directory. Plugin IDs may
+    # add a suffix to this component, so match the component prefix rather than
+    # hard-coding the currently shipped locale and plugin directory name.
+    if (
+        len(parts) >= 4
+        and parts[:2] == ["website", "i18n"]
+        and (
+            parts[3] == I18N_DOCS_PLUGIN_PREFIX
+            or parts[3].startswith(I18N_DOCS_PLUGIN_PREFIX + "-")
+        )
+    ):
+        return True
 
     # Check extension repos
     for repo in EXCLUDE_EXT_REPOS:

--- a/tests/test_build_release.py
+++ b/tests/test_build_release.py
@@ -24,6 +24,28 @@ def test_release_zip_excludes_generated_docs_but_keeps_runtime_assets():
     assert build_release.should_exclude(flagged_doc) is True
     assert build_release.should_exclude(flagged_doc.replace("/", "\\")) is True
 
+    localized_doc = (
+        "website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/"
+        "user-guide/skills/optional/autonomous-ai-agents/"
+        "autonomous-ai-agents-blackbox.md"
+    )
+    assert build_release.should_exclude(localized_doc) is True
+    assert build_release.should_exclude(localized_doc.replace("/", "\\")) is True
+    assert (
+        build_release.should_exclude(
+            "website/i18n/es/docusaurus-plugin-content-docs-version-v2/intro.md"
+        )
+        is True
+    )
+
+    # Preserve non-doc localization resources used by the website build.
+    assert (
+        build_release.should_exclude(
+            "website/i18n/zh-Hans/docusaurus-theme-classic/navbar.json"
+        )
+        is False
+    )
+
     # The portable updater seeds its model cache from this tracked manifest.
     assert build_release.should_exclude("website/static/api/model-catalog.json") is False
 


### PR DESCRIPTION
## Summary

Follow-up to #57 and issue #56. The final v1.3.7 archive audit found that Docusaurus's localized content tree still contained a generated copy of the Norton-flagged Blackbox documentation page.

This change excludes localized `website/i18n/<locale>/docusaurus-plugin-content-docs*` trees from portable release ZIPs without hard-coding the current locale or plugin ID. It preserves the real optional skill and runtime model catalog.

## Validation

- `venv\\Scripts\\python.exe -m pytest tests\\test_build_release.py -q` — 6 passed
- `venv\\Scripts\\python.exe -m ruff check build_release.py tests\\test_build_release.py` — passed
- `git diff --check` — passed
- Full v1.3.7 archive build/audit:
  - 3,361 entries
  - 0 `website/docs/**` entries
  - 0 localized `docusaurus-plugin-content-docs*` entries
  - 0 generated `autonomous-ai-agents-blackbox.md` copies
  - actual `optional-skills/.../blackbox/SKILL.md` present
  - `website/static/api/model-catalog.json` present
  - launchers present
  - no forbidden development/runtime-state directories

Norton itself is not installed locally, so its proprietary signature cannot be rerun here. This removes every generated copy of the exact content class it reported while preserving the feature.