### PR TITLE
fix(deps): remediate July npm security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15541,9 +15541,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -15560,7 +15560,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -15582,9 +15582,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "yauzl": "^3.3.1",
     "fast-uri": "3.1.4",
     "js-yaml": "4.3.0",
+    "postcss": "8.5.23",
     "tar": "7.5.20"
   },
   "engines": {


### PR DESCRIPTION
## Summary

- pin the root workspace's transitive PostCSS resolution to patched `8.5.23`
- refresh the root lockfile, including PostCSS's patched Nano ID dependency
- keep the runtime-compatible React Router 7 line and avoid an incompatible brace-expansion major override

The website PostCSS instance was fixed separately by Dependabot PR #62, which was rebase-merged to preserve Dependabot's authorship.

## Security assessment

### Fixed by this PR

`GHSA-r28c-9q8g-f849` / root `postcss`: both root dependency paths (`sanitize-html` and `vite`) now deduplicate to PostCSS 8.5.23. `npm audit --package-lock-only` no longer reports PostCSS.

### Documented as not used after merge

- `GHSA-qwww-vcr4-c8h2` / `react-router`: the advisory affects only unstable RSC APIs. Repository-wide inspection found only standard `react-router-dom` client routing (BrowserRouter, HashRouter, Routes, Link, and navigation hooks), with no RSC imports or execution path. The patched `react-router@8.3.0` has no matching `react-router-dom@8.3.0` release and requires Node >=22.22, while Hermes supports Node 20.
- `GHSA-mh99-v99m-4gvg` / website `brace-expansion`: reachable only through `@docusaurus/core -> serve-handler@6.1.7 -> minimatch@3.1.5` in local static-site preview tooling, not the portable runtime or deployed static site. Forcing brace-expansion 5.0.8 would break minimatch 3's CommonJS callable-export contract.

After this change lands and clean CI passes, those two alerts will be dismissed as `not_used` with these exact reasons and monitored for compatible upstream releases.

## Validation

- `git diff --check`
- parsed root and website manifests as JSON
- `npm ls postcss --all --package-lock-only` (root): all paths -> 8.5.23
- `npm ls postcss --all --package-lock-only` (website): all paths -> 8.5.23
- `npm audit --package-lock-only --json` (root and website): no PostCSS finding
- repository-wide React Router API inspection

Full clean install/build validation is delegated to this PR's GitHub Actions runners because npm's local Windows reification step stalled while rebuilding generated `node_modules`; no tracked source was affected.