### PR TITLE
fix(desktop): align Electron builder pin

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -147,7 +147,7 @@
     "wait-on": "^9.0.5"
   },
   "build": {
-    "electronVersion": "40.10.2",
+    "electronVersion": "41.10.3",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",


### PR DESCRIPTION
Aligns `build.electronVersion` with the existing exact `electron` devDependency (`41.10.3`). This is intentionally isolated from Dependabot PR #76.