### PR TITLE
fix(security): remediate npm alerts and bound docs builds

### DIFF
--- a/.github/workflows/docs-site-checks.yml
+++ b/.github/workflows/docs-site-checks.yml
@@ -9,6 +9,10 @@ permissions:
 jobs:
   docs-site-checks:
     runs-on: ubuntu-latest
+    # Docusaurus currently depends on image-size 2.0.2, whose malformed
+    # ICNS/JXL/HEIF parsers can loop indefinitely and has no patched release.
+    # Bound untrusted PR builds until Docusaurus can consume a fixed version.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/skills-index-freshness.yml
+++ b/.github/workflows/skills-index-freshness.yml
@@ -5,11 +5,10 @@ name: Skills Index Freshness Check
 # stale OR the file disappears entirely OR a major source has collapsed,
 # this workflow opens a GitHub issue so we hear about it before users do.
 #
-# Triggered every 4 hours so we catch a stuck cron within one tick.
+# The portable repository does not own the upstream skills index, so this
+# inherited watchdog remains manually dispatchable but is not scheduled here.
 
 on:
-  schedule:
-    - cron: '0 */4 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -1,9 +1,8 @@
 name: Build Skills Index
 
 on:
-  schedule:
-    # Run twice daily: 6 AM and 6 PM UTC
-    - cron: "0 6,18 * * *"
+  # The portable repository does not own the upstream skills index. Keep the
+  # workflow for upstream-sync compatibility without scheduling no-op runs.
   workflow_dispatch: # Manual trigger
   push:
     branches: [main]
@@ -13,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  actions: write # to trigger deploy-site.yml on schedule
+  actions: write # to trigger deploy-site.yml after a manual refresh
 
 jobs:
   build-index:
@@ -42,12 +41,12 @@ jobs:
           path: website/static/api/skills-index.json
           retention-days: 7
 
-  # Re-trigger the docs deploy so the refreshed index lands on the live site.
-  # The deploy itself is owned by deploy-site.yml (which crawls and deploys
-  # everything in one pipeline); we just kick it on a schedule.
+  # Re-trigger the docs deploy after an explicitly requested refresh.
+  # The deploy itself is owned by deploy-site.yml, which crawls and deploys
+  # everything in one pipeline.
   trigger-deploy:
     needs: build-index
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Deploy Site workflow

--- a/package-lock.json
+++ b/package-lock.json
@@ -12976,9 +12976,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -15551,9 +15551,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@assistant-ui/store": "0.2.13",
     "yauzl": "^3.3.1",
     "fast-uri": "3.1.5",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "postcss": "8.5.23",
     "tar": "7.5.22"
   },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9379,9 +9379,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -14593,9 +14593,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -39,7 +39,7 @@
     "@babel/core": "7.29.7",
     "body-parser": "1.20.6",
     "brace-expansion": "1.1.18",
-    "dompurify": "3.4.12",
+    "dompurify": "3.4.13",
     "fast-uri": "3.1.5",
     "http-proxy-middleware": "2.0.10",
     "joi": "17.13.4",


### PR DESCRIPTION
## Summary

- update the root and website lockfiles past the nanoid, js-yaml, and DOMPurify advisories
- stop this standalone portable repository from scheduling upstream-only skills-index workflows that always skip
- bound docs CI to 20 minutes while Docusaurus depends on the unpatched image-size 2.0.2 parser

## Validation

- clean npm ci in the root workspace and website
- root npm audit: zero vulnerabilities
- npm run build in website (both locales completed; pre-existing broken-link warnings remain)
- npm run typecheck --workspace apps/desktop
- workflow YAML parse and git diff --check

## Remaining advisory

image-size 2.0.2 has no patched npm release, and current Docusaurus still depends on it. The CI timeout bounds malformed-image resource exhaustion from untrusted PR builds; the advisory should remain documented as a tolerated, mitigated risk until Docusaurus can consume a fixed release.