### PR TITLE
fix(gui): keep startup responsive during local model discovery

### DIFF
--- a/gui/agent_bridge.py
+++ b/gui/agent_bridge.py
@@ -154,25 +154,6 @@ class AgentBridge:
             pass
         return None
 
-    def _validate_startup_model(self):
-        """Detect LM Studio on startup and register any discovered models.
-        Default is always cloud mode — user switches to local via UI.
-        """
-        self._active_provider = "cloud"
-
-        # Probe LM Studio in case it's running — register models for sidebar
-        url = self._resolve_lm_studio_url()
-        if url:
-            try:
-                from gui.lm_studio import LMStudioClient
-                client = LMStudioClient(base_url=url)
-                for m in client.list_models_api():
-                    mid = m.get("id", "")
-                    if mid:
-                        self._known_local_models.add(mid)
-            except Exception:
-                pass
-
     def get_model(self) -> str:
         if not hasattr(self, '_selected_model') or not self._selected_model:
             model_config = self.config.get("model", {})

--- a/gui/app.py
+++ b/gui/app.py
@@ -1190,9 +1190,6 @@ class HermesGUI:
         self._stream_bubble = None  # Active streaming bubble
         self._has_streamed = False   # True once any stream delta arrived
 
-        # Validate startup model (local model + LM Studio check)
-        self.bridge._validate_startup_model()
-
         self._build_menu()
         self._build_layout()
 

--- a/tests/test_portable_gui.py
+++ b/tests/test_portable_gui.py
@@ -2,6 +2,7 @@ import importlib
 import queue
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 
 def _bridge_shell(agent_bridge, tmp_path):
@@ -32,6 +33,71 @@ def test_portable_gui_modules_import():
     )
 
     assert all(importlib.import_module(module) for module in modules)
+
+
+def test_gui_startup_never_probes_lm_studio_on_tk_thread(monkeypatch):
+    """Network discovery starts later in Sidebar.refresh_models' worker thread."""
+    from gui import app
+
+    class FakeRoot:
+        def withdraw(self):
+            pass
+
+        def title(self, _value):
+            pass
+
+        def geometry(self, _value):
+            pass
+
+        def minsize(self, *_args):
+            pass
+
+        def deiconify(self):
+            pass
+
+        def after(self, *_args):
+            pass
+
+        def bind(self, *_args):
+            pass
+
+        def protocol(self, *_args):
+            pass
+
+    class FakeBridge:
+        _startup_fallback = False
+
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def _validate_startup_model(self):
+            raise AssertionError("startup must not perform the LM Studio network probe")
+
+        def get_model(self):
+            return "provider/model"
+
+        def _is_local_model(self, _model):
+            return False
+
+        def _is_model_configured(self):
+            return True
+
+    monkeypatch.setattr(app.tk, "Tk", FakeRoot)
+    monkeypatch.setattr(app, "AgentBridge", FakeBridge)
+    monkeypatch.setattr(app, "init_dpi_scaling", lambda _root: None)
+    monkeypatch.setattr(app, "apply_theme", lambda _root: None)
+    monkeypatch.setattr(app, "center_window", lambda *_args: None)
+    monkeypatch.setattr(app, "get_missing_keys", lambda: [])
+    monkeypatch.setattr(app.HermesGUI, "_build_menu", lambda _self: None)
+
+    def fake_layout(gui):
+        gui.status_bar = SimpleNamespace(set_model=lambda _model: None)
+        gui.sidebar = SimpleNamespace(set_model=lambda _model: None)
+
+    monkeypatch.setattr(app.HermesGUI, "_build_layout", fake_layout)
+    monkeypatch.setattr(app.HermesGUI, "_add_msg", lambda *_args: None)
+
+    app.HermesGUI()
 
 
 def test_gui_keeps_portable_branding_and_has_no_stale_version_label():


### PR DESCRIPTION
## Summary

- remove the redundant synchronous LM Studio startup probe that ran after the Tk window was shown but before `mainloop()`
- rely on the existing sidebar discovery worker for local-model detection
- add a regression test proving GUI construction never invokes the network probe on Tk's main thread

## Root cause

The v1.4.2 restoration revived legacy startup code that deiconified the window and then probed two LM Studio HTTP endpoints with three-second timeouts. Windows could therefore display the new window as unresponsive before Tk's event loop began.

## Validation

- 34 focused GUI/updater/archive/custom-tool tests passed
- Ruff and `git diff --check` passed
- native Windows Tk smoke test intentionally stalled LM Studio discovery for five seconds; the window processed 28 heartbeat callbacks in 1.8 seconds and closed normally