### PR TITLE
fix(portable): make clean Windows setup fail closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Or run:
 hermes.bat update --backup --yes
 ```
 
-This updates from `aivrar/portable-hermes-agent`, makes a backup when requested, and preserves runtime folders such as `.hermes/`, `.hermes/custom_tools/`, `.hermes/extensions/`, `extensions/`, and `python_embedded/`.
+This updates from `aivrar/portable-hermes-agent`, makes a backup when requested, and preserves runtime folders such as `.hermes/`, `.hermes/custom_tools/`, `.hermes/extensions/`, `extensions/`, and `python_embedded/`. The portable Node.js runtime is stored under `HERMES_HOME/node/`, so it also survives both update types without modifying a system Node installation.
 
 If you also want newer upstream Hermes code, start Hermes after the Portable update and ask:
 

--- a/START_HERE.txt
+++ b/START_HERE.txt
@@ -75,7 +75,8 @@ Notes:
 
 - Keep the extracted folder together. Portable runtimes such as python_embedded,
   extensions, and node_modules stay beside the app and survive updates.
-- User settings, skills, workflows, sessions, and API keys stay in the active
-  Hermes home (normally %USERPROFILE%\.hermes) and survive both update types.
+- User settings, skills, workflows, sessions, API keys, and the managed Node.js
+  runtime stay in the active Hermes home (normally %USERPROFILE%\.hermes) and
+  survive both update types.
 - API keys belong in the setup wizard or the Hermes-home .env file, not in Git.
 - Extension servers for TTS, Music, and ComfyUI install on first use.

--- a/install.bat
+++ b/install.bat
@@ -30,6 +30,8 @@ set "PYTHON_VERSION=3.13.12"
 set "PYTHON_URL=https://www.python.org/ftp/python/3.13.12/python-3.13.12-embed-amd64.zip"
 set "PYTHON_ZIP=%SCRIPT_DIR%python_embedded.zip"
 set "TCLTK_URL=https://www.python.org/ftp/python/3.13.12/amd64/tcltk.msi"
+set "TCLTK_MSI=%SCRIPT_DIR%tcltk.msi"
+set "TCLTK_TEMP=%SCRIPT_DIR%_tcltk_temp"
 
 :: ============================================
 :: Step 1: Download Embedded Python
@@ -109,14 +111,16 @@ if %errorlevel% neq 0 (
 :: ============================================
 echo [STEP 4/10] Installing build tools...
 "%PYTHON_EXE%" -m pip install setuptools wheel --quiet 2>nul
+if errorlevel 1 (
+    echo ERROR: Failed to install Python build tools.
+    exit /b 1
+)
 
 :: ============================================
 :: Step 5: Install Tkinter (GUI support)
 :: ============================================
 if not exist "%PYTHON_DIR%\Lib\tkinter" (
     echo [STEP 5/10] Installing Tkinter GUI support...
-    set "TCLTK_MSI=%SCRIPT_DIR%tcltk.msi"
-    set "TCLTK_TEMP=%SCRIPT_DIR%_tcltk_temp"
 
     powershell -NoProfile -ExecutionPolicy Bypass -Command ^
         "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;" ^
@@ -128,7 +132,7 @@ if not exist "%PYTHON_DIR%\Lib\tkinter" (
         :: "start /wait msiexec /a" can return before extraction completes on
         :: Windows 11 Enterprise with restrictive Group Policy, leaving DLLs absent.
         powershell -NoProfile -ExecutionPolicy Bypass -Command ^
-            "Start-Process msiexec.exe -ArgumentList '/a','\"!TCLTK_MSI!\"','/qn','TARGETDIR=\"!TCLTK_TEMP!\"' -Wait -NoNewWindow"
+            "$p = Start-Process msiexec.exe -ArgumentList '/a','\"!TCLTK_MSI!\"','/qn','TARGETDIR=\"!TCLTK_TEMP!\"' -Wait -WindowStyle Hidden -PassThru; if ($p.ExitCode -ne 0) { exit $p.ExitCode }"
         if exist "!TCLTK_TEMP!\DLLs" (
             xcopy /E /Y /Q "!TCLTK_TEMP!\DLLs\*" "%PYTHON_DIR%\DLLs\" >nul 2>nul
             copy /Y "!TCLTK_TEMP!\DLLs\*.dll" "%PYTHON_DIR%\" >nul 2>nul
@@ -139,15 +143,26 @@ if not exist "%PYTHON_DIR%\Lib\tkinter" (
             xcopy /E /Y /Q "!TCLTK_TEMP!\libs\*" "%PYTHON_DIR%\libs\" >nul 2>nul
             echo [OK] Tkinter installed.
         ) else (
-            echo [WARN] Tkinter extraction failed - GUI may not work.
+            echo ERROR: Tkinter extraction failed.
+            del "!TCLTK_MSI!" 2>nul
+            exit /b 1
         )
         rmdir /S /Q "!TCLTK_TEMP!" 2>nul
         del "!TCLTK_MSI!" 2>nul
     ) else (
-        echo [WARN] Could not download Tkinter - GUI may not work.
+        echo ERROR: Could not download Tkinter.
+        exit /b 1
     )
 ) else (
     echo [OK] Tkinter already installed.
+)
+
+set "TCL_LIBRARY=%PYTHON_DIR%\tcl\tcl8.6"
+set "TK_LIBRARY=%PYTHON_DIR%\tcl\tk8.6"
+"%PYTHON_EXE%" -c "import tkinter; tkinter.Tcl()" >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: Embedded Python cannot load Tkinter after installation.
+    exit /b 1
 )
 
 :: ============================================
@@ -184,6 +199,10 @@ echo        (this may take several minutes on first run)
 "%PYTHON_EXE%" -m pip install -e "%SCRIPT_DIR%." --quiet 2>nul
 if errorlevel 1 (
     "%PYTHON_EXE%" -m pip install -r "%SCRIPT_DIR%requirements.txt" --quiet 2>nul
+    if errorlevel 1 (
+        echo ERROR: Failed to install required Python dependencies.
+        exit /b 1
+    )
 )
 
 :: Guarantee the project root is on sys.path regardless of editable-install outcome.
@@ -197,6 +216,9 @@ if not exist "!PTH_FILE!" (
 
 :: All optional extras
 "%PYTHON_EXE%" -m pip install -e "%SCRIPT_DIR%.[messaging,cron,cli,mcp,honcho,pty,tts-premium,homeassistant]" --quiet 2>nul
+if errorlevel 1 (
+    echo [WARN] Some optional integrations could not be installed.
+)
 
 :: Mini-swe-agent
 if exist "%SCRIPT_DIR%mini-swe-agent\pyproject.toml" (
@@ -205,6 +227,10 @@ if exist "%SCRIPT_DIR%mini-swe-agent\pyproject.toml" (
 
 :: Extra packages needed for Windows GUI
 "%PYTHON_EXE%" -m pip install Pillow ddgs lmstudio --quiet 2>nul
+if errorlevel 1 (
+    echo ERROR: Failed to install required Windows GUI packages.
+    exit /b 1
+)
 
 echo [OK] Python dependencies installed.
 
@@ -212,17 +238,31 @@ echo [OK] Python dependencies installed.
 :: Step 8: Node.js dependencies
 :: ============================================
 echo [STEP 8/10] Installing Node.js dependencies...
-where node >nul 2>&1
-if %errorlevel% equ 0 (
-    if exist "%SCRIPT_DIR%package.json" (
-        cd /d "%SCRIPT_DIR%"
-        npm install --quiet 2>nul
-        echo [OK] Node.js dependencies installed.
-    )
-) else (
-    echo [INFO] Node.js not found - browser tools and WhatsApp bridge won't be available.
-    echo        Install Node.js from https://nodejs.org/ and re-run this installer.
-)
+echo        Provisioning a portable Hermes-managed Node.js runtime...
+set "NPM_PATH_FILE=%SCRIPT_DIR%.portable_npm_path.tmp"
+"%PYTHON_EXE%" -c "from pathlib import Path; from hermes_constants import bootstrap_hermes_managed_node; Path(r'%NPM_PATH_FILE%').write_text(bootstrap_hermes_managed_node() or '', encoding='utf-8')" 2>nul
+set "NPM_CMD="
+if exist "%NPM_PATH_FILE%" set /p "NPM_CMD="<"%NPM_PATH_FILE%"
+del "%NPM_PATH_FILE%" 2>nul
+if not defined NPM_CMD goto :node_install_failed
+if not exist "%NPM_CMD%" goto :node_install_failed
+for %%I in ("%NPM_CMD%") do set "MANAGED_NODE_DIR=%%~dpI"
+set "PATH=%MANAGED_NODE_DIR%;%PATH%"
+cd /d "%SCRIPT_DIR%"
+call "%NPM_CMD%" install --quiet 2>nul
+if errorlevel 1 goto :node_dependencies_failed
+echo [OK] Portable Node.js dependencies installed.
+goto :node_install_complete
+
+:node_install_failed
+echo ERROR: Could not provision the portable Node.js runtime.
+exit /b 1
+
+:node_dependencies_failed
+echo ERROR: Failed to install Node.js dependencies.
+exit /b 1
+
+:node_install_complete
 
 :: ============================================
 :: Step 9: Environment and config files
@@ -282,6 +322,21 @@ if errorlevel 1 (
     )
 )
 echo [OK] Skills synced.
+
+:: ============================================
+:: Final verification - never claim success for a partial install
+:: ============================================
+echo [VERIFY] Checking embedded GUI, profile, and portable skills...
+"%PYTHON_EXE%" -c "import os, tkinter; from pathlib import Path; import gui.app, hermes_cli; tkinter.Tcl(); h=Path(os.environ['HERMES_HOME']); required=['.env','config.yaml','permissions.json','SOUL.md','node/node.exe','node/npm.cmd','skills/getting-started/SKILL.md','skills/lm-studio/SKILL.md','skills/extensions/portable-comfyui/SKILL.md','skills/extensions/music-server/SKILL.md','skills/extensions/tts-server/SKILL.md']; missing=[p for p in required if not (h/p).is_file()]; assert not missing, 'missing profile files: '+', '.join(missing)" >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: Installation verification failed. Run install.bat again to repair it.
+    exit /b 1
+)
+if not exist "%SCRIPT_DIR%node_modules\.package-lock.json" (
+    echo ERROR: Node.js dependency verification failed. Run install.bat again to repair it.
+    exit /b 1
+)
+echo [OK] Embedded GUI, profile, and portable skills verified.
 
 :: ============================================
 :: Done!

--- a/skills/extensions/portable-comfyui/SKILL.md
+++ b/skills/extensions/portable-comfyui/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: comfyui
+name: portable-comfyui
 description: Generate and manage images with portable ComfyUI.
 version: "1.0"
 author: aivrar

--- a/tests/test_build_release.py
+++ b/tests/test_build_release.py
@@ -35,7 +35,7 @@ def test_tracked_release_inventory_contains_complete_portable_surface():
         "gui/permissions.py",
         "gui/permissions_panel.py",
         "gui/theme.py",
-        "skills/extensions/comfyui/SKILL.md",
+        "skills/extensions/portable-comfyui/SKILL.md",
         "skills/extensions/music-server/SKILL.md",
         "skills/extensions/tts-server/SKILL.md",
         "skills/getting-started/SKILL.md",
@@ -95,6 +95,44 @@ def test_windows_launchers_keep_runtime_state_in_active_hermes_home():
 
     for launcher in (start, cli_launcher, gui_launcher, updater):
         assert 'set "PIP_PREFIX=' not in launcher
+
+
+def test_windows_installer_fails_closed_instead_of_finishing_partial_setup():
+    installer = (Path(build_release.PROJECT_ROOT) / "install.bat").read_text(
+        encoding="utf-8"
+    )
+
+    # Variables referenced with percent expansion inside a parenthesized block
+    # must be assigned before that block is parsed.
+    assert installer.index('set "TCLTK_MSI=') < installer.index(
+        'if not exist "%PYTHON_DIR%\\Lib\\tkinter" ('
+    )
+
+    # npm is a .cmd shim on Windows. Without CALL it terminates install.bat and
+    # silently skips profile creation, skill sync, and the success/failure gate.
+    assert 'from hermes_constants import bootstrap_hermes_managed_node' in installer
+    assert 'call "%NPM_CMD%" install --quiet' in installer
+    assert "\n        npm install --quiet" not in installer
+
+    # Success is conditional on the real embedded runtime and portable profile
+    # surface, not just on individual download commands returning.
+    assert 'import os, tkinter; from pathlib import Path; import gui.app, hermes_cli' in installer
+    assert "skills/getting-started/SKILL.md" in installer
+    assert "skills/extensions/tts-server/SKILL.md" in installer
+    assert "Installation verification failed" in installer
+
+
+def test_portable_comfyui_skill_does_not_collide_with_upstream_skill():
+    root = Path(build_release.PROJECT_ROOT)
+    portable = (root / "skills/extensions/portable-comfyui/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    upstream = (root / "skills/creative/comfyui/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "\nname: portable-comfyui\n" in portable
+    assert "\nname: comfyui\n" in upstream
 
 
 def test_release_zip_excludes_development_only_dirs():

--- a/tests/tools/test_portable_custom_tools.py
+++ b/tests/tools/test_portable_custom_tools.py
@@ -78,7 +78,9 @@ def test_extension_skill_ports_match_portable_runtime():
     tts_skill = (REPO_ROOT / "skills/extensions/tts-server/SKILL.md").read_text(
         encoding="utf-8"
     )
-    comfyui_skill = (REPO_ROOT / "skills/extensions/comfyui/SKILL.md").read_text(
+    comfyui_skill = (
+        REPO_ROOT / "skills/extensions/portable-comfyui/SKILL.md"
+    ).read_text(
         encoding="utf-8"
     )
 

--- a/tests/tools/test_update_hermes_tool.py
+++ b/tests/tools/test_update_hermes_tool.py
@@ -261,7 +261,7 @@ def test_zip_overlay_preserves_portable_runtime_and_source_paths():
     assert update_hermes_tool._is_preserved_overlay_path("tools/update_hermes_tool.py")
     assert update_hermes_tool._is_preserved_overlay_path("gui/future_panel.py")
     assert update_hermes_tool._is_preserved_overlay_path(
-        "skills/extensions/comfyui/SKILL.md"
+        "skills/extensions/portable-comfyui/SKILL.md"
     )
     assert update_hermes_tool._is_preserved_overlay_path("tests/portable-policy.py")
     assert not update_hermes_tool._is_preserved_overlay_path("run_agent.py")

--- a/tools/update_hermes_tool.py
+++ b/tools/update_hermes_tool.py
@@ -99,7 +99,7 @@ _PORTABLE_REQUIRED_TREE_FILES = {
     "gui/app.py",
     "gui/agent_bridge.py",
     "gui/theme.py",
-    "skills/extensions/comfyui/SKILL.md",
+    "skills/extensions/portable-comfyui/SKILL.md",
     "skills/extensions/music-server/SKILL.md",
     "skills/extensions/tts-server/SKILL.md",
     "skills/getting-started/SKILL.md",


### PR DESCRIPTION
## Summary

- fix clean Windows installs dropping Tkinter because a percent-expanded MSI path was assigned inside the same parsed batch block
- preserve batch control flow by invoking the npm `.cmd` shim with `call`
- provision Hermes-managed Node/npm under `HERMES_HOME` instead of depending on or modifying an incompatible system npm
- fail closed when required Python packages, Tkinter, Node dependencies, profile files, or portable skills are missing
- give the portable ComfyUI skill a unique identity/path so it coexists with upstream Hermes' separate ComfyUI skill
- document managed Node persistence across both update channels

## Reproduction against v1.4.3

A clean install from the public release exited after `npm install`, before steps 9/10, while reporting exit code 0. Direct checks showed:

- `tkinter` and `gui.app` could not import
- no `HERMES_HOME` profile/config/skills were created
- portable ComfyUI collided with and was migrated into the upstream ComfyUI skill path

## Validation

- 36 focused archive/installer/GUI/custom-tool/updater tests passed
- all five portable skills pass the skill linter
- real clean Windows install from a newly built ZIP downloaded Python 3.13.12 and Tkinter, installed Python dependencies, provisioned isolated Node 22.23.2/npm 10.9.8, installed 1,335 Node packages with 0 npm vulnerabilities, created config/profile state, and synced 85 skills
- final installer verification passed for embedded GUI imports, Tcl initialization, managed Node, configuration, SOUL, and all portable skills
- installed CLI reported Hermes Agent v0.20.6
- installed GUI processed 25 UI heartbeats in 1.8 seconds while LM Studio discovery was deliberately stalled
- hidden MSI extraction separately verified required Tkinter files